### PR TITLE
[Add] agregar script para HTTP

### DIFF
--- a/PC1/src/check_http.sh
+++ b/PC1/src/check_http.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Variables configurables
+URL="${URL:-https://example.com}"
+POST_URL="${POST_URL:-https://httpbin.org/post}"
+
+OUT_DIR="out"
+LOG_FILE="$OUT_DIR/http.log"
+mkdir -p "$OUT_DIR"
+
+echo "[INFO] Ejecutando chequeos HTTP..." | tee "$LOG_FILE"
+
+# --- GET ---
+echo "[HTTP][GET] Probando GET a $URL" | tee -a "$LOG_FILE"
+curl -sI "$URL" | sed -n '1,20p' | tee -a "$LOG_FILE"
+curl -s -o /dev/null -w "[HTTP][GET] Código de estado: %{http_code}\n" "$URL" | tee -a "$LOG_FILE"
+
+# --- POST ---
+echo "[HTTP][POST] Probando POST a $POST_URL (payload: {\"ping\":\"1\"})" | tee -a "$LOG_FILE"
+curl -sI -X POST -d '{"ping":"1"}' -H "Content-Type: application/json" "$POST_URL" | sed -n '1,20p' | tee -a "$LOG_FILE" || true
+curl -s -o /dev/null -w "[HTTP][POST] Código de estado: %{http_code}\n" -X POST -d '{"ping":"1"}' -H "Content-Type: application/json" "$POST_URL" | tee -a "$LOG_FILE" || true
+
+echo "[INFO] Chequeos HTTP terminados. Evidencias en $LOG_FILE"

--- a/PC1/src/main.sh
+++ b/PC1/src/main.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Sprint 1 - ejecutando script principal"


### PR DESCRIPTION
# Agregar script principal y chequeos HTTP

## Descripción

Este pull request introduce un script principal de entrada y un módulo Bash para realizar chequeos HTTP (métodos GET y POST). El objetivo es contar con un pipeline inicial de validación de endpoints web, registrando las evidencias en un archivo de log.

## Cambios principales

- Nuevo script: `src/main.sh`
  - Punto de entrada del Sprint 1.
  - Mensaje inicial de ejecución.

- Nuevo script: `src/check_http.sh`
  - Configuración robusta con `set -euo pipefail`.
  - Variables configurables:
    - `URL` (por defecto: `https://example.com`)
    - `POST_URL` (por defecto: `https://httpbin.org/post`)
  - Realiza:
    - **GET**: consulta encabezados y estado HTTP.
    - **POST**: envía payload JSON de prueba y valida respuesta.
  - Evidencias guardadas en `out/http.log`.

## ¿Cómo probar?

1. Ejecutar el script manualmente:
   ```bash
   bash src/check_http.sh

Closes #2 